### PR TITLE
Add: Brazilian Portuguese translation

### DIFF
--- a/src/main/resources/assets/armorchroma/lang/pt_br.json
+++ b/src/main/resources/assets/armorchroma/lang/pt_br.json
@@ -1,7 +1,7 @@
 {
     "modmenu.descriptionTranslation.armorchroma": "Adiciona cores, incluindo o couro tingido, e reflexos encantados à barra de armadura.",
 
-    "text.autoconfig.armorchroma.title": "Config. do Armor Chroma",
+    "text.autoconfig.armorchroma.title": "Ajustes do Armor Chroma",
     "text.autoconfig.armorchroma.option.enabled": "Habilitar mod",
     "text.autoconfig.armorchroma.option.renderGlint": "Renderizar reflexo",
     "text.autoconfig.armorchroma.option.renderGlint.@Tooltip": "Exibe o reflexo encantado nos ícones.",

--- a/src/main/resources/assets/armorchroma/lang/pt_br.json
+++ b/src/main/resources/assets/armorchroma/lang/pt_br.json
@@ -1,0 +1,20 @@
+{
+    "modmenu.descriptionTranslation.armorchroma": "Adiciona cores, incluindo o couro tingido, e reflexos encantados à barra de armadura.",
+
+    "text.autoconfig.armorchroma.title": "Config. do Armor Chroma",
+    "text.autoconfig.armorchroma.option.enabled": "Habilitar mod",
+    "text.autoconfig.armorchroma.option.renderGlint": "Renderizar reflexo",
+    "text.autoconfig.armorchroma.option.renderGlint.@Tooltip": "Exibe o reflexo encantado nos ícones.",
+    "text.autoconfig.armorchroma.option.glintIntensity": "Intensidade do reflexo",
+    "text.autoconfig.armorchroma.option.renderBackground": "Renderizar fundo",
+    "text.autoconfig.armorchroma.option.renderBackground.@Tooltip": "Exibe ícones vazios quando os pontos\nde armadura forem menores que 20.",
+    "text.autoconfig.armorchroma.option.compressBar": "Comprimir barra",
+    "text.autoconfig.armorchroma.option.compressBar.@Tooltip": "Comprime a barra em bordas de cores diferentes\nquando os pontos de armadura ultrapassarem 20.",
+    "text.autoconfig.armorchroma.option.displayedArmorCap": "Limite de armadura exibido",
+    "text.autoconfig.armorchroma.option.displayedArmorCap.@Tooltip": "Os pontos máximos de armadura a serem exibidos.",
+    "text.autoconfig.armorchroma.option.reverse": "Inverter ordem da armadura",
+    "text.autoconfig.armorchroma.option.showMaterialInTooltip": "Exibir material em descrições",
+    "text.autoconfig.armorchroma.option.showMaterialInTooltip.@Tooltip": "Define se o material das armaduras devem\nser exibidos nas descrições do inventário.",
+
+    "armorchroma.tooltip.material": "Material da armadura: %s"
+}

--- a/src/main/resources/assets/armorchroma/lang/pt_br.json
+++ b/src/main/resources/assets/armorchroma/lang/pt_br.json
@@ -1,6 +1,4 @@
 {
-    "modmenu.descriptionTranslation.armorchroma": "Adiciona cores, incluindo o couro tingido, e reflexos encantados à barra de armadura.",
-
     "text.autoconfig.armorchroma.title": "Ajustes do Armor Chroma",
     "text.autoconfig.armorchroma.option.enabled": "Habilitar mod",
     "text.autoconfig.armorchroma.option.renderGlint": "Renderizar reflexo",
@@ -14,7 +12,9 @@
     "text.autoconfig.armorchroma.option.displayedArmorCap.@Tooltip": "Os pontos máximos de armadura a serem exibidos.",
     "text.autoconfig.armorchroma.option.reverse": "Inverter ordem da armadura",
     "text.autoconfig.armorchroma.option.showMaterialInTooltip": "Exibir material em descrições",
-    "text.autoconfig.armorchroma.option.showMaterialInTooltip.@Tooltip": "Define se o material das armaduras devem\nser exibidos nas descrições do inventário.",
+    "text.autoconfig.armorchroma.option.showMaterialInTooltip.@Tooltip": "Define se o material das armaduras deve\nser exibido nas descrições do inventário.",
 
-    "armorchroma.tooltip.material": "Material da armadura: %s"
+    "armorchroma.tooltip.material": "Material da armadura: %s",
+
+    "modmenu.descriptionTranslation.armorchroma": "Adiciona cores, incluindo o couro tingido, e reflexos encantados à barra de armadura."
 }


### PR DESCRIPTION
## This PR adds the Brazilian Portuguese translation to Armor Chroma.
I've also added a new key-value pair for Mod Menu's description when viewing the list of mods, which I'd also recommend other languages doing so it is, indeed, fully translated. Everything was tested and it is working flawlessly, following Crowdin's official rules and formatting.